### PR TITLE
More options

### DIFF
--- a/RFunction.R
+++ b/RFunction.R
@@ -4,13 +4,13 @@ library('lubridate')
 
 # remains to update: 
 
-# 1. the setting duplicates handling shall give only either "first" or "last" (in second mt_filter_unique), now it is not used and set to "last" fix
+# 1. the setting duplicates handling shall give only either "first" or "last" (in second mt_filter_unique), now it is not used and set to "last" fix --> activated
 
 # 2. EURING_1 und EURING_3 options shall be added, but as they dont work and the frontend does not allow it for selection, not yet --> probably temporary bug, now it works
 
 # 3. add fix for deployment_id (to be named from indivdual_local_identifier and tag_local_identifier) - there should be some code from Bart --> fixed
 
-# 4. select animals - should be changed with Clemens: animals==0 for all animals also in future added ones (make ticket that this info shall be written somewhere or additinal check-box)
+# 4. select animals - should be changed with Clemens: animals==0 for all animals also in future added ones (make ticket that this info shall be written somewhere or additinal check-box) --> made ticket
 
 rFunction = function(data=NULL, username,password,study,select_sensors,incl_outliers=FALSE,minarg=FALSE,animals=NULL,thin=FALSE,thin_numb=6,thin_unit="hours",timestamp_start=NULL,timestamp_end=NULL,duplicates_handling="first",event_reduc=NULL, ...) {
 

--- a/RFunction.R
+++ b/RFunction.R
@@ -81,6 +81,17 @@ rFunction = function(data=NULL, username,password,study,select_sensors,incl_outl
     if (!is.null(event_reduc))
     {
       arguments[["event_reduction_profile"]] <- event_reduc #can have values "EURING_01" or "EURING_03"
+      # ToDo: see if this "ignoring time settings" is needed or can be solved were else
+      if(!is.null(timestamp_start)){
+        arguments["timestamp_start"] <- NULL
+        logger.info(paste0("timestamp_start cannot be used in combination with the setting ",event_reduc))
+      }
+      if(!is.null(timestamp_end)){
+        arguments["timestamp_end"] <- NULL
+        logger.info(paste0("timestamp_end cannot be used in combination with the setting ",event_reduc))
+      }
+      
+      # attributes=all does not work, a vector is needed
       if(!minarg){
         if(length(select_sensors)==1){
           arguments[["attributes"]] <- movebank_retrieve(entity_type = "study_attribute", study_id = study, sensor_type_id = select_sensors)$short_name

--- a/RFunction.R
+++ b/RFunction.R
@@ -152,7 +152,7 @@ rFunction = function(data=NULL, username,password,study,select_sensors,incl_outl
       n_dupl <- length(which(duplicated(paste(mt_track_id(locs),mt_time(locs)))))
       logger.info(paste("Your data has",n_dupl, "duplicated location-time records. We removed here those with less info and then select the first if still duplicated."))
       locs <- mt_filter_unique(locs,criterion="subsets")
-      locs <- mt_filter_unique(locs,criterion="last")
+      locs <- mt_filter_unique(locs,criterion=duplicates_handling)
     }
     
     #thinning to first location of given intervals (thus, resulting time lag can be shorter some times)

--- a/app-configuration.json
+++ b/app-configuration.json
@@ -12,5 +12,6 @@
     "timestamp_start": null,
     "timestamp_end": null,
     "config_version": 1,
-    "duplicates_handling": "first"
+    "duplicates_handling": "first",
+    "event_reduc": "EURING_03"
     }

--- a/app-configuration.json
+++ b/app-configuration.json
@@ -11,7 +11,7 @@
     "thin_unit": "hour",
     "timestamp_start": null,
     "timestamp_end": null,
-    "config_version": 1,
+    "config_version": 0,
     "duplicates_handling": "first",
     "event_reduc": "EURING_03"
     }


### PR DESCRIPTION
Hi @andreakoelzsch, 
- reduction profiles work, but attributes=all does not work, so a vector of attributes needs to be stated -> done
- reduction profiles ignore timestamp start and end -> acounted for, but maybe can be done more elegantly
- talking to Bart, he suggested to name the tracks "animalName (deply_id:9834)" because one animal an be tagged several times with the same tag, with large timegaps between the depolyments, so, they should be different tracks. -> I've done it now like this, we can discuss it
- 
I only have tested the Rfunction, and not the sdk because of the credential thing. But it should all work. Hopefully